### PR TITLE
Added .gitattributes to override Windows line endings (issue #55)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf


### PR DESCRIPTION
Added .gitattributes file to override Windows line endings.  This is to resolve issue #55.

How this works is that it takes all text files and auto converts the line endings to LF upon commit, but it does NOT convert away from LF, even on Windows.

See Issue #55 for details on the issue at hand.