### PR TITLE
Fix Nextion v1.1 upload protocol

### DIFF
--- a/firmware/NSPanelManagerFirmware/lib/NSPanel/NSPanel.cpp
+++ b/firmware/NSPanelManagerFirmware/lib/NSPanel/NSPanel.cpp
@@ -712,7 +712,7 @@ bool NSPanel::_updateTFTOTA() {
     LOG_INFO("Starting upload using v1.1 protocol.");
     commandString = "whmi-wri ";
     commandString.append(std::to_string(file_size));
-    commandString.append(",1");
+    commandString.append(",");
     commandString.append(std::to_string(NSPMConfig::instance->tft_upload_baud));
     commandString.append(",1");
   }


### PR DESCRIPTION
I think commit 8ae97454 introduced a regression into the v1.1 upload protocol, and is mistakenly prepending a `1` to the baud rate.

Here are some logs, the first two runs are with the v1.2 protocol, the third is the same baud rate on v1.1, the fourth is the 38400 on v1.1.  Both the v1.1 sessions have the `1` prepended.

```
C0:49:EF:D1:A7:28;DEBUG; NSPanel.cpp:723 f(._updateTFTOTA) Sending TFT upload command: whmi-wris 5452668,115200,1
C0:49:EF:D1:A7:28;DEBUG; NSPanel.cpp:723 f(._updateTFTOTA) Sending TFT upload command: whmi-wris 5452668,115200,1
C0:49:EF:D1:A7:28;DEBUG; NSPanel.cpp:723 f(._updateTFTOTA) Sending TFT upload command: whmi-wri 5452668,1115200,1
C0:49:EF:D1:A7:28;DEBUG; NSPanel.cpp:723 f(._updateTFTOTA) Sending TFT upload command: whmi-wri 5452668,138400,1

```