### PR TITLE
Enable doc search using Algolia

### DIFF
--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -141,6 +141,15 @@ const config: Config = {
       theme: prismThemes.github,
       darkTheme: prismThemes.dracula,
     },
+    algolia: {
+      appId: 'ORQYQLTO1S',
+      apiKey: '196785515dac5daeccbd1a5dce6125c2',
+      indexName: 'nspanelmanager',
+      contextualSearch: false,
+      searchParameters: {},
+      searchPagePath: 'search',
+      insights: false,
+    },
   } satisfies Preset.ThemeConfig,
 };
 


### PR DESCRIPTION
Implement #218 

## Changes

- [x] Setup Algolia plugin following the documentation https://docusaurus.io/docs/search#contextual-search

## How was it tested?
![2024-12-04_08-57](https://github.com/user-attachments/assets/4a3ea693-dda7-4f4e-9e32-6d4f25d6fbbe)

