### PR TITLE
Fix item_select dropdown not updating input on selection

### DIFF
--- a/docker/web/nspanelmanager/web/components/item_select/item_select.html
+++ b/docker/web/nspanelmanager/web/components/item_select/item_select.html
@@ -28,19 +28,19 @@
     </div>
 
     <script>
-    $(document).ready(() => {
-      $(".item_select_{{ name }}_option").on('click', (event) => {
-        const element = $(event.currentTarget);
-        $("#item_select_{{ name }}_input").val(element.data('item-id'));
-        $("#item_select_{{ name }}_input").attr("data-raw-base64", element.data('raw-base64'));
+    // Use mousedown (not click) so we fire before the browser moves focus to the body
+    // on a non-focusable element, which would collapse the dropdown via :focus-within
+    // before a click event could ever land. preventDefault() keeps the input focused.
+    $(document).on('mousedown', ".item_select_{{ name }}_option", function(event) {
+        event.preventDefault();
+        const element = $(this);
+        $("#item_select_{{ name }}_input").val(element.data('item-id')); // Set value from pressed item to
+        $("#item_select_{{ name }}_input").attr("data-raw-base64", element.data('raw-base64')); // Set value from pressed item to
 
         // Update what item is shown as selected in the list
         $(".item_select_{{ name }}_option").attr('data-selected', 'false');
         element.attr('data-selected', 'true');
-
-        // Blur the input to collapse the dropdown
-        $("#item_select_{{ name }}_input").blur();
-      })
+        $("#item_select_{{ name }}_input").blur(); // Blur the input to collapse the dropdown
     });
 
     document.getElementById("item_select_{{ name }}_input").addEventListener('input', () => {

--- a/docker/web/nspanelmanager/web/components/item_select/item_select.html
+++ b/docker/web/nspanelmanager/web/components/item_select/item_select.html
@@ -20,7 +20,7 @@
         <div id="dropdown_content_container_{{ name }}" class="overflow-x-clip overflow-y-scroll rounded-b-box bg-neutral text-neutral-content border-accent border border-t-0 z-20 w-full p-2 max-h-0 hidden group-focus-within:max-h-72 group-focus-within:h-auto group-focus-within:block transition-all duration-100 ease-in-out">
             <ul class="w-full" id="item_select_options_{{ name }}">
                 {% for item in items %}
-                    <button type="button" class="w-full text-left"><li data-selected="{% if item.item_id == selected %}true{% else %}false{% endif %}" class="item_select_{{ name }}_option py-1 px-2 rounded-btn data-[selected=true]:bg-base-300 data-[selected=true]:text-info hover:bg-base-100 text-wrap w-full cursor-pointer" data-label="{{ item.label }}" data-item-id="{{ item.item_id }}" data-raw-base64="{{ item|jsonify|base64_encode }}">{{ item.label }} ({{ item.item_id }})</li></button>
+                    <li data-selected="{% if item.item_id == selected %}true{% else %}false{% endif %}" class="item_select_{{ name }}_option py-1 px-2 rounded-btn data-[selected=true]:bg-base-300 data-[selected=true]:text-info hover:bg-base-100 text-wrap w-full text-left cursor-pointer" data-label="{{ item.label }}" data-item-id="{{ item.item_id }}" data-raw-base64="{{ item|jsonify|base64_encode }}">{{ item.label }} ({{ item.item_id }})</li>
                 {% endfor %}
             </ul>
             <span class="italic text-sm justify-center text-warning hidden" id="item_select_{{ name }}_no_items">No items found.</span>
@@ -30,14 +30,16 @@
     <script>
     $(document).ready(() => {
       $(".item_select_{{ name }}_option").on('click', (event) => {
-        $("#item_select_{{ name }}").focus();
         const element = $(event.currentTarget);
-        $("#item_select_{{ name }}_input").val(element.data('item-id')); // Set value from pressed item to
-        $("#item_select_{{ name }}_input").attr("data-raw-base64", element.data('raw-base64')); // Set value from pressed item to
+        $("#item_select_{{ name }}_input").val(element.data('item-id'));
+        $("#item_select_{{ name }}_input").attr("data-raw-base64", element.data('raw-base64'));
 
         // Update what item is shown as selected in the list
         $(".item_select_{{ name }}_option").attr('data-selected', 'false');
         element.attr('data-selected', 'true');
+
+        // Blur the input to collapse the dropdown
+        $("#item_select_{{ name }}_input").blur();
       })
     });
 
@@ -46,23 +48,19 @@
         var has_uppercase = /[A-Z]/.test(filter_text);
 
         var num_items_shown = 0;
-        $("#item_select_options_{{ name }} > button > li").each(function () {
+        $("#item_select_options_{{ name }} > li").each(function () {
           if(has_uppercase) {
             if ($(this).attr("data-label").includes(filter_text) || $(this).attr("data-item-id").includes(filter_text) || filter_text == "") {
-              $(this).parent().show();
               $(this).show();
               num_items_shown++;
             } else {
-              $(this).parent().hide();
               $(this).hide();
             }
           } else if(!has_uppercase) {
             if ($(this).attr("data-label").toLowerCase().includes(filter_text.toLowerCase()) || $(this).attr("data-item-id").toLowerCase().includes(filter_text.toLowerCase()) || filter_text == "") {
-              $(this).parent().show();
               $(this).show();
               num_items_shown++;
             } else {
-              $(this).parent().hide();
               $(this).hide();
             }
           }


### PR DESCRIPTION
## Summary

- Clicking a non-focusable `<li>` causes the browser to move focus to the body on `mousedown`, stripping `:focus-within` from the `.group` div and collapsing the dropdown (`display:none`) before a `click` event can land — so the handler never fires
- Switches from `click` to `mousedown` with `event.preventDefault()` to intercept the selection before focus moves, keeping the input focused and the dropdown visible, then explicitly `blur()`s the input to close
- Removes the invalid `<button>` wrapper around `<li>` elements (`<button>` inside `<ul>` containing `<li>` is invalid HTML) and updates the filter selector from `> button > li` to `> li`

## Test plan

- [x] Tested by James Mulcahy: selecting a Home Assistant Scene from the dropdown now correctly populates the input field

🤖 Generated with [Claude Code](https://claude.com/claude-code)