### PR TITLE
Fix clock thread spinning at midnight due to missing tm_mday increment

### DIFF
--- a/docker/MQTTManager/src/main.cpp
+++ b/docker/MQTTManager/src/main.cpp
@@ -98,16 +98,9 @@ void publish_time_and_date() {
       next_minute_tm.tm_hour++;
       if (next_minute_tm.tm_hour >= 24) { // We went over to next day
         next_minute_tm.tm_hour = 0;
-
-        // Handle day change
-        if (next_minute_tm.tm_mday >= 32) { // We went over to next month
-          next_minute_tm.tm_mday = 1;
-          next_minute_tm.tm_mon++;
-          if (next_minute_tm.tm_mon >= 12) { // We went over to next year
-            next_minute_tm.tm_mon = 0;
-            next_minute_tm.tm_year++;
-          }
-        }
+        next_minute_tm.tm_mday++;
+        // mktime (called below) normalises month/year overflow and handles
+        // varying month lengths and leap years, so no manual rollover needed.
       }
     }
 


### PR DESCRIPTION
## Summary

- `publish_time_and_date` never incremented `tm_mday` when crossing midnight, so `mktime` normalised the struct back to midnight of the *current* day (already in the past) — causing `sleep_until` to return immediately and the date message to be published twice in quick succession each night before recovering
- The existing manual rollover check (`tm_mday >= 32`) was unreachable dead code (tm_mday was never incremented) and would have been wrong anyway for February and 30-day months
- Fix: increment `tm_mday` and remove the manual rollover logic; `mktime` is C-standard-specified to normalise out-of-range `struct tm` fields (e.g. January 32 → February 1, month 12 → January of next year) including leap-year-aware February, and is already called on the very next line

## Test plan

- [ ] Deploy and observe clock MQTT messages across a midnight boundary — expect exactly one publish per minute with no double-fire at 00:00
- [ ] Verify correct date rollover at end of month (including February in a non-leap year) and end of year

🤖 Generated with [Claude Code](https://claude.com/claude-code)