### PR TITLE
Fix TypeError in download_tft and checksum_tft_file error paths

### DIFF
--- a/docker/web/nspanelmanager/web/views.py
+++ b/docker/web/nspanelmanager/web/views.py
@@ -980,7 +980,7 @@ def download_tft(request, panel_id):
     elif is_us_panel == "True" and us_panel_orientation == "vertical":
         tft_file = "HMI_files/tft_automation/us/output_" + selected_tft + "/gui.tft"
     else:
-        print("ERROR! Could not determine TFT file for NSPanel with ID " + panel_id)
+        print(f"ERROR! Could not determine TFT file for NSPanel with ID {panel_id}")
 
     fs = FileSystemStorage()
     if "Range" in request.headers and request.headers["Range"].startswith("bytes="):
@@ -1046,7 +1046,7 @@ def checksum_tft_file(request, panel_id):
     elif is_us_panel == "True" and us_panel_orientation == "vertical":
         tft_file = "HMI_files/tft_automation/us/output_" + selected_tft + "/gui.tft"
     else:
-        print("ERROR! Could not determine TFT file for NSPanel with ID " + panel_id)
+        print(f"ERROR! Could not determine TFT file for NSPanel with ID {panel_id}")
 
     return HttpResponse(get_file_md5sum(tft_file))
 


### PR DESCRIPTION
## Summary

- `download_tft` and `checksum_tft_file` both have an error-logging `else` branch that is reached when an unknown `is_us_panel`/`us_panel_orientation` combination is encountered
- `panel_id` is captured as `<int:panel_id>` in the URL pattern, so `"...ID " + panel_id` raises `TypeError: can only concatenate str (not "int") to str`, masking the original problem with a secondary exception
- Fixed both occurrences by converting to f-strings

## Test plan

- [ ] Confirm no regressions in normal TFT download and checksum flows
- [ ] Confirm the error message is logged correctly when an unknown orientation is supplied

🤖 Generated with [Claude Code](https://claude.com/claude-code)