### PR TITLE
Fix scene drag-and-drop failing with 'Did not find existing entity to move'

### DIFF
--- a/docker/web/nspanelmanager/web/htmx.py
+++ b/docker/web/nspanelmanager/web/htmx.py
@@ -854,7 +854,7 @@ def get_entity_in_page_slot(page_id, slot_id):
 def partial_move_entity(request):
     existing_entity_in_slot = get_entity_in_page_slot(request.POST["page_id"], request.POST["slot_id"])
     new_entity_in_slot = None
-    if request.POST["new_entity_type"] == "Scene":
+    if request.POST["new_entity_type"] == "scene":
         new_entity_in_slot = Scene.objects.get(id=request.POST["new_entity_id"])
     else:
         try:


### PR DESCRIPTION
## Summary

- The room settings panel view scene drag-and-drop was broken — moving a scene to any slot (empty or occupied) always returned `"Did not find existing entity to move!"`.
- Root cause: `partial_move_entity` in `htmx.py` compared `new_entity_type` against `"Scene"` (capital S), but the `nspanel_entities_page` component sets `entity.type = "scene"` (lowercase), so the check always failed and fell through to `Entity.objects.get()`, which then raised an exception.
- Fix: change the comparison to lowercase `"scene"` to match what the template sends.

## Test plan

- [x] Manually tested: dragging a scene to an empty slot now moves it correctly
- [x] Manually tested: dragging a scene onto an occupied slot now swaps the two scenes correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)