### PR TITLE
Trigger all-rooms status re-publish after load_entities completes

### DIFF
--- a/docker/MQTTManager/include/entity_manager/entity_manager.cpp
+++ b/docker/MQTTManager/include/entity_manager/entity_manager.cpp
@@ -97,6 +97,14 @@ void EntityManager::load_entities() {
   SPDLOG_INFO("Total loaded NSPanels: {}", EntityManager::_nspanels.size());
   SPDLOG_INFO("Total loaded Rooms: {}", EntityManager::_rooms.size());
   SPDLOG_INFO("Total loaded Entities: {}", EntityManager::_entities.size());
+
+  // Force a re-publish of the all-rooms status now that rooms/lights are fully
+  // loaded. The background thread fires before load_entities completes; a proto3
+  // message with all-zero values serializes to zero bytes, and an MQTT retained
+  // publish with an empty payload clears the retained message on the broker.
+  // Without this call, panels would never receive the aggregate until the next
+  // light-state change.
+  EntityManager::_room_updated_callback(nullptr);
 }
 
 void EntityManager::attach_entity_added_listener(void (*listener)(std::shared_ptr<MqttManagerEntity>)) {


### PR DESCRIPTION
## Summary

- `EntityManager::init()` starts the `update_all_rooms_status` background thread **before** calling `load_entities()`. The thread fires its initial publish after a ~250 ms backoff. If `load_entities` hasn't finished by then, `_rooms` is empty and the resulting proto3 `NSPanelRoomStatus` serializes to zero bytes (all fields at their default). Publishing a zero-byte payload to a retained topic **clears** the retained message on the broker per the MQTT spec.
- After that point the thread only wakes when `_room_updated_callback` fires (on light state changes). With stable lights — including right after server startup — no callback fires, so panels that connect later never receive the all-rooms aggregate status.
- Fix: call `_room_updated_callback(nullptr)` at the end of `load_entities()` to force the thread to re-publish with actual room data. Also corrects the behaviour after a SIGUSR1 config reload.

## Test plan

- [ ] Restart the NSPanelManager server while panels are connected — verify panels receive the all-rooms aggregate status without needing a light state change
- [ ] Verify panels that connect after startup also receive the status
- [ ] Confirm SIGUSR1 config reload re-publishes updated aggregate

🤖 Generated with [Claude Code](https://claude.com/claude-code)