### PR TITLE
Always emit triggering room context for HA scene/script activations

### DIFF
--- a/docker/MQTTManager/include/entity_manager/entity_manager.cpp
+++ b/docker/MQTTManager/include/entity_manager/entity_manager.cpp
@@ -783,7 +783,12 @@ void EntityManager::_command_callback(NSPanelMQTTManagerCommand &command) {
           SPDLOG_ERROR("Received command to toggle light entity in slot {} in page with ID {} but entity could not be cast to a light.", command.toggle_entity_from_entities_page().entity_slot(), command.toggle_entity_from_entities_page().entity_page_id());
         }
       } else {
-        (*entity)->toggle();
+        auto scene = std::dynamic_pointer_cast<Scene>(*entity);
+        if (scene) {
+          scene->activate(EntityManager::get_room_id_for_panel_id(command.nspanel_id()));
+        } else {
+          (*entity)->toggle();
+        }
       }
     } else {
       SPDLOG_DEBUG("Received command to toggle entity in slot {} in page with ID {} bot did not find such an entity.", command.toggle_entity_from_entities_page().entity_slot(), command.toggle_entity_from_entities_page().entity_page_id());
@@ -891,6 +896,14 @@ std::expected<std::shared_ptr<NSPanel>, EntityManager::EntityError> EntityManage
   }
   SPDLOG_TRACE("Did not find NSPanel by ID {}", id);
   return std::unexpected(EntityManager::EntityError::NOT_FOUND);
+}
+
+std::optional<int32_t> EntityManager::get_room_id_for_panel_id(uint32_t nspanel_id) {
+  auto nspanel = EntityManager::get_nspanel_by_id(nspanel_id);
+  if (nspanel.has_value()) {
+    return (*nspanel)->get_default_room_id();
+  }
+  return std::nullopt;
 }
 
 std::expected<std::shared_ptr<NSPanel>, EntityManager::EntityError> EntityManager::get_nspanel_by_mac(std::string mac) {

--- a/docker/MQTTManager/include/entity_manager/entity_manager.cpp
+++ b/docker/MQTTManager/include/entity_manager/entity_manager.cpp
@@ -785,8 +785,7 @@ void EntityManager::_command_callback(NSPanelMQTTManagerCommand &command) {
       } else {
         auto scene = std::dynamic_pointer_cast<Scene>(*entity);
         if (scene) {
-          auto room_id = EntityManager::get_room_id_for_panel_id(command.nspanel_id());
-          scene->activate(room_id ? std::optional(*room_id) : std::nullopt);
+          scene->activate(EntityManager::get_room_id_for_panel_id(command.nspanel_id()));
         } else {
           (*entity)->toggle();
         }

--- a/docker/MQTTManager/include/entity_manager/entity_manager.cpp
+++ b/docker/MQTTManager/include/entity_manager/entity_manager.cpp
@@ -785,7 +785,8 @@ void EntityManager::_command_callback(NSPanelMQTTManagerCommand &command) {
       } else {
         auto scene = std::dynamic_pointer_cast<Scene>(*entity);
         if (scene) {
-          scene->activate(EntityManager::get_room_id_for_panel_id(command.nspanel_id()));
+          auto room_id = EntityManager::get_room_id_for_panel_id(command.nspanel_id());
+          scene->activate(room_id ? std::optional(*room_id) : std::nullopt);
         } else {
           (*entity)->toggle();
         }
@@ -898,12 +899,12 @@ std::expected<std::shared_ptr<NSPanel>, EntityManager::EntityError> EntityManage
   return std::unexpected(EntityManager::EntityError::NOT_FOUND);
 }
 
-std::optional<int32_t> EntityManager::get_room_id_for_panel_id(uint32_t nspanel_id) {
+std::expected<int32_t, EntityManager::EntityError> EntityManager::get_room_id_for_panel_id(uint32_t nspanel_id) {
   auto nspanel = EntityManager::get_nspanel_by_id(nspanel_id);
   if (nspanel.has_value()) {
     return (*nspanel)->get_default_room_id();
   }
-  return std::nullopt;
+  return std::unexpected(EntityManager::EntityError::NOT_FOUND);
 }
 
 std::expected<std::shared_ptr<NSPanel>, EntityManager::EntityError> EntityManager::get_nspanel_by_mac(std::string mac) {

--- a/docker/MQTTManager/include/entity_manager/entity_manager.hpp
+++ b/docker/MQTTManager/include/entity_manager/entity_manager.hpp
@@ -206,7 +206,7 @@ public:
 
   static std::expected<std::shared_ptr<NSPanel>, EntityError> get_nspanel_by_id(uint id);
   static std::expected<std::shared_ptr<NSPanel>, EntityError> get_nspanel_by_mac(std::string mac);
-  static std::optional<int32_t> get_room_id_for_panel_id(uint32_t nspanel_id);
+  static std::expected<int32_t, EntityError> get_room_id_for_panel_id(uint32_t nspanel_id);
 
 private:
   static inline std::vector<std::shared_ptr<MqttManagerEntity>> _entities;

--- a/docker/MQTTManager/include/entity_manager/entity_manager.hpp
+++ b/docker/MQTTManager/include/entity_manager/entity_manager.hpp
@@ -206,6 +206,7 @@ public:
 
   static std::expected<std::shared_ptr<NSPanel>, EntityError> get_nspanel_by_id(uint id);
   static std::expected<std::shared_ptr<NSPanel>, EntityError> get_nspanel_by_mac(std::string mac);
+  static std::optional<int32_t> get_room_id_for_panel_id(uint32_t nspanel_id);
 
 private:
   static inline std::vector<std::shared_ptr<MqttManagerEntity>> _entities;

--- a/docker/MQTTManager/include/nspanel/nspanel.cpp
+++ b/docker/MQTTManager/include/nspanel/nspanel.cpp
@@ -1,4 +1,5 @@
 #include "nspanel.hpp"
+#include <scenes/scene.hpp>
 #include "database_manager/database_manager.hpp"
 #include "entity_manager/entity_manager.hpp"
 #include "mqtt_manager/mqtt_manager.hpp"
@@ -1401,7 +1402,12 @@ void NSPanel::command_callback(NSPanelMQTTManagerCommand &command) {
             auto entity = EntityManager::get_entity_by_id<MqttManagerEntity>(MQTT_MANAGER_ENTITY_TYPE::ANY, this->_settings.button1_detached_mode_entity_id.value());
             if (entity) {
               if ((*entity)->can_toggle()) {
-                (*entity)->toggle();
+                auto scene = std::dynamic_pointer_cast<Scene>(*entity);
+                if (scene) {
+                  scene->activate(this->get_default_room_id());
+                } else {
+                  (*entity)->toggle();
+                }
               }
             } else
               SPDLOG_ERROR("Tried to toggle detached entity via panel but no entity was found with configured ID '{}'.", this->_settings.button1_detached_mode_entity_id.value());
@@ -1430,7 +1436,12 @@ void NSPanel::command_callback(NSPanelMQTTManagerCommand &command) {
             auto entity = EntityManager::get_entity_by_id<MqttManagerEntity>(MQTT_MANAGER_ENTITY_TYPE::ANY, this->_settings.button2_detached_mode_entity_id.value());
             if (entity) {
               if ((*entity)->can_toggle()) {
-                (*entity)->toggle();
+                auto scene = std::dynamic_pointer_cast<Scene>(*entity);
+                if (scene) {
+                  scene->activate(this->get_default_room_id());
+                } else {
+                  (*entity)->toggle();
+                }
               }
             } else
               SPDLOG_ERROR("Tried to toggle detached entity via panel but no entity was found with configured ID '{}'.", this->_settings.button2_detached_mode_entity_id.value());

--- a/docker/MQTTManager/include/scenes/home_assistant_scene.cpp
+++ b/docker/MQTTManager/include/scenes/home_assistant_scene.cpp
@@ -36,7 +36,7 @@ void HomeAssistantScene::reload_config() {
   }
 }
 
-void HomeAssistantScene::activate(std::optional<int32_t> triggering_room_id) {
+void HomeAssistantScene::activate(std::expected<int32_t, EntityManager::EntityError> triggering_room_id) {
   SPDLOG_INFO("Activating scene {}::{}.", this->_id, this->_name);
 
   if (this->_entity_id.starts_with("scene.")) {

--- a/docker/MQTTManager/include/scenes/home_assistant_scene.cpp
+++ b/docker/MQTTManager/include/scenes/home_assistant_scene.cpp
@@ -36,8 +36,9 @@ void HomeAssistantScene::reload_config() {
   }
 }
 
-void HomeAssistantScene::activate() {
+void HomeAssistantScene::activate(std::optional<int32_t> triggering_room_id) {
   SPDLOG_INFO("Activating scene {}::{}.", this->_id, this->_name);
+
   if (this->_entity_id.starts_with("scene.")) {
     nlohmann::json service_data;
     service_data["type"] = "call_service";
@@ -50,11 +51,23 @@ void HomeAssistantScene::activate() {
     nlohmann::json context;
     context["scene_name"] = this->_name;
     context["scene_id"] = this->_id;
-    auto room = EntityManager::get_room(this->_room_id);
-    if (!this->_is_global && room.has_value()) {
-      context["room_name"] = (*room)->get_name();
-      context["room_id"] = this->_room_id;
+
+    if (triggering_room_id.has_value()) {
+      auto triggering_room = EntityManager::get_room(*triggering_room_id);
+      if (triggering_room.has_value()) {
+        context["triggering_room_id"] = *triggering_room_id;
+        context["triggering_room_name"] = (*triggering_room)->get_name();
+      }
     }
+
+    if (!this->_is_global) {
+      auto scene_room = EntityManager::get_room(this->_room_id);
+      if (scene_room.has_value()) {
+        context["scene_room_id"] = this->_room_id;
+        context["scene_room_name"] = (*scene_room)->get_name();
+      }
+    }
+
     service_data["service_data"]["variables"]["nspanelmanager"] = context;
     SPDLOG_DEBUG("Sending script with context: {}", context.dump());
     service_data["type"] = "call_service";

--- a/docker/MQTTManager/include/scenes/home_assistant_scene.hpp
+++ b/docker/MQTTManager/include/scenes/home_assistant_scene.hpp
@@ -7,7 +7,7 @@ class HomeAssistantScene : public Scene {
 public:
   HomeAssistantScene(uint32_t id);
   void reload_config();
-  void activate(std::optional<int32_t> triggering_room_id = std::nullopt);
+  void activate(std::expected<int32_t, EntityManager::EntityError> triggering_room_id = std::unexpected(EntityManager::EntityError::NOT_FOUND));
   void save();
   void remove();
   uint16_t get_id();

--- a/docker/MQTTManager/include/scenes/home_assistant_scene.hpp
+++ b/docker/MQTTManager/include/scenes/home_assistant_scene.hpp
@@ -7,7 +7,7 @@ class HomeAssistantScene : public Scene {
 public:
   HomeAssistantScene(uint32_t id);
   void reload_config();
-  void activate();
+  void activate(std::optional<int32_t> triggering_room_id = std::nullopt);
   void save();
   void remove();
   uint16_t get_id();

--- a/docker/MQTTManager/include/scenes/nspm_scene.cpp
+++ b/docker/MQTTManager/include/scenes/nspm_scene.cpp
@@ -47,7 +47,7 @@ void NSPMScene::reload_config() {
   }
 }
 
-void NSPMScene::activate() {
+void NSPMScene::activate(std::optional<int32_t> triggering_room_id) {
   SPDLOG_INFO("Activating scene {}::{}.", this->_id, this->_name);
   try {
     auto light_states = database_manager::database.get_all<database_manager::SceneLightState>(sqlite_orm::where(sqlite_orm::c(&database_manager::SceneLightState::scene_id) == this->_id));

--- a/docker/MQTTManager/include/scenes/nspm_scene.cpp
+++ b/docker/MQTTManager/include/scenes/nspm_scene.cpp
@@ -47,7 +47,7 @@ void NSPMScene::reload_config() {
   }
 }
 
-void NSPMScene::activate(std::optional<int32_t> triggering_room_id) {
+void NSPMScene::activate(std::expected<int32_t, EntityManager::EntityError> triggering_room_id) {
   SPDLOG_INFO("Activating scene {}::{}.", this->_id, this->_name);
   try {
     auto light_states = database_manager::database.get_all<database_manager::SceneLightState>(sqlite_orm::where(sqlite_orm::c(&database_manager::SceneLightState::scene_id) == this->_id));

--- a/docker/MQTTManager/include/scenes/nspm_scene.hpp
+++ b/docker/MQTTManager/include/scenes/nspm_scene.hpp
@@ -15,7 +15,7 @@ public:
   ~NSPMScene();
 
   void reload_config();
-  void activate(std::optional<int32_t> triggering_room_id = std::nullopt);
+  void activate(std::expected<int32_t, EntityManager::EntityError> triggering_room_id = std::unexpected(EntityManager::EntityError::NOT_FOUND));
   void save();
   void remove();
   uint16_t get_id();

--- a/docker/MQTTManager/include/scenes/nspm_scene.hpp
+++ b/docker/MQTTManager/include/scenes/nspm_scene.hpp
@@ -15,7 +15,7 @@ public:
   ~NSPMScene();
 
   void reload_config();
-  void activate();
+  void activate(std::optional<int32_t> triggering_room_id = std::nullopt);
   void save();
   void remove();
   uint16_t get_id();

--- a/docker/MQTTManager/include/scenes/openhab_scene.cpp
+++ b/docker/MQTTManager/include/scenes/openhab_scene.cpp
@@ -36,7 +36,7 @@ void OpenhabScene::reload_config() {
   }
 }
 
-void OpenhabScene::activate(std::optional<int32_t> triggering_room_id) {
+void OpenhabScene::activate(std::expected<int32_t, EntityManager::EntityError> triggering_room_id) {
   SPDLOG_INFO("Activating scene {}::{}.", this->_id, this->_name);
 
   std::string openhab_trigger_scene_url = fmt::format("{}/rest/rules/{}/runnow", MqttManagerConfig::get_setting_with_default<std::string>(MQTT_MANAGER_SETTING::OPENHAB_ADDRESS), this->_entity_id);

--- a/docker/MQTTManager/include/scenes/openhab_scene.cpp
+++ b/docker/MQTTManager/include/scenes/openhab_scene.cpp
@@ -36,7 +36,7 @@ void OpenhabScene::reload_config() {
   }
 }
 
-void OpenhabScene::activate() {
+void OpenhabScene::activate(std::optional<int32_t> triggering_room_id) {
   SPDLOG_INFO("Activating scene {}::{}.", this->_id, this->_name);
 
   std::string openhab_trigger_scene_url = fmt::format("{}/rest/rules/{}/runnow", MqttManagerConfig::get_setting_with_default<std::string>(MQTT_MANAGER_SETTING::OPENHAB_ADDRESS), this->_entity_id);

--- a/docker/MQTTManager/include/scenes/openhab_scene.hpp
+++ b/docker/MQTTManager/include/scenes/openhab_scene.hpp
@@ -8,7 +8,7 @@ class OpenhabScene : public Scene {
 public:
   OpenhabScene(uint32_t id);
   void reload_config();
-  void activate(std::optional<int32_t> triggering_room_id = std::nullopt);
+  void activate(std::expected<int32_t, EntityManager::EntityError> triggering_room_id = std::unexpected(EntityManager::EntityError::NOT_FOUND));
   void save();
   void remove();
   uint16_t get_id();

--- a/docker/MQTTManager/include/scenes/openhab_scene.hpp
+++ b/docker/MQTTManager/include/scenes/openhab_scene.hpp
@@ -8,7 +8,7 @@ class OpenhabScene : public Scene {
 public:
   OpenhabScene(uint32_t id);
   void reload_config();
-  void activate();
+  void activate(std::optional<int32_t> triggering_room_id = std::nullopt);
   void save();
   void remove();
   uint16_t get_id();

--- a/docker/MQTTManager/include/scenes/scene.cpp
+++ b/docker/MQTTManager/include/scenes/scene.cpp
@@ -17,7 +17,7 @@ bool Scene::can_toggle() {
 void Scene::toggle() {
   // Satisfies MqttManagerEntity's pure virtual. In practice all scene activations go through
   // activate(triggering_room_id) directly, so this path should never be reached.
-  this->activate(std::nullopt);
+  this->activate(std::unexpected(EntityManager::EntityError::NOT_FOUND));
 }
 
 bool Scene::is_global() {

--- a/docker/MQTTManager/include/scenes/scene.cpp
+++ b/docker/MQTTManager/include/scenes/scene.cpp
@@ -15,7 +15,9 @@ bool Scene::can_toggle() {
 }
 
 void Scene::toggle() {
-  this->activate();
+  // Satisfies MqttManagerEntity's pure virtual. In practice all scene activations go through
+  // activate(triggering_room_id) directly, so this path should never be reached.
+  this->activate(std::nullopt);
 }
 
 bool Scene::is_global() {

--- a/docker/MQTTManager/include/scenes/scene.hpp
+++ b/docker/MQTTManager/include/scenes/scene.hpp
@@ -1,10 +1,11 @@
 #ifndef MQTT_MANAGER_SCENE_BASE_H
 #define MQTT_MANAGER_SCENE_BASE_H
 #include "entity/entity.hpp"
+#include <optional>
 
 class Scene : public MqttManagerEntity {
 public:
-  virtual void activate() = 0;
+  virtual void activate(std::optional<int32_t> triggering_room_id = std::nullopt) = 0;
   virtual void save() = 0;
   virtual void remove() = 0;
   virtual void reload_config() = 0;
@@ -17,7 +18,7 @@ public:
   bool is_global();
 
   // The same as activate()
-  void toggle();
+  void toggle() override;
 
   virtual std::string get_name() = 0;
   virtual bool can_save() = 0;

--- a/docker/MQTTManager/include/scenes/scene.hpp
+++ b/docker/MQTTManager/include/scenes/scene.hpp
@@ -1,11 +1,12 @@
 #ifndef MQTT_MANAGER_SCENE_BASE_H
 #define MQTT_MANAGER_SCENE_BASE_H
 #include "entity/entity.hpp"
-#include <optional>
+#include "entity_manager/entity_manager.hpp"
+#include <expected>
 
 class Scene : public MqttManagerEntity {
 public:
-  virtual void activate(std::optional<int32_t> triggering_room_id = std::nullopt) = 0;
+  virtual void activate(std::expected<int32_t, EntityManager::EntityError> triggering_room_id = std::unexpected(EntityManager::EntityError::NOT_FOUND)) = 0;
   virtual void save() = 0;
   virtual void remove() = 0;
   virtual void reload_config() = 0;


### PR DESCRIPTION
## Summary

- When activating a Home Assistant `script.`, always include `scene_name`, `scene_id`, `triggering_room_id`, `triggering_room_name`, `scene_room_id`, and `scene_room_name` in the `nspanelmanager` variables context
- Previously, room context was only sent for room-specific scenes; global scenes received no room information
- Global scenes now receive the room of the panel that triggered them, allowing HA scripts to take room-specific actions while remaining globally defined
- Panels browsing another room's scene page correctly report the panel's own room as the triggering room

## Implementation

- Added `activate(std::optional<int32_t> triggering_room_id)` to the `Scene` base class; all scene subclasses updated to match
- `EntityManager` resolves the triggering room from the `nspanel_id` in the command via a new `get_room_id_for_panel_id()` helper
- NSPanel hardware button presses pass the panel's own room directly
- `Scene::toggle()` (no-arg) is retained to satisfy `MqttManagerEntity`'s pure virtual, but all real activations now go through `activate()` directly

## Test plan

- [x] Global scene triggered from home panel — `triggering_room_id` matches panel's room
- [x] Room-specific scene triggered from its own room — both `triggering_room_*` and `scene_room_*` populated
- [x] Room-specific scene triggered from a panel in a different room — `triggering_room_*` reflects the triggering panel's room, `scene_room_*` reflects the scene's own room
- [x] `scene.` entity type (non-script) — unaffected, no context sent

🤖 Generated with [Claude Code](https://claude.com/claude-code)